### PR TITLE
fix: implement notifications API with proper serialization and pagina…

### DIFF
--- a/backend/spherre/app/__init__.py
+++ b/backend/spherre/app/__init__.py
@@ -3,6 +3,7 @@ from flask import Flask
 from spherre.app.config import config
 from spherre.app.extensions import cors, db, jwt, migrate
 from spherre.app.views.accounts import accounts_blueprint
+from spherre.app.views.notifications import notifications_blueprint
 
 
 def create_app(config_name="development"):
@@ -19,5 +20,6 @@ def create_app(config_name="development"):
 
     # Register blueprints
     app.register_blueprint(accounts_blueprint)
+    app.register_blueprint(notifications_blueprint)
 
     return app

--- a/backend/spherre/app/serializers/notifications.py
+++ b/backend/spherre/app/serializers/notifications.py
@@ -1,0 +1,15 @@
+from marshmallow import Schema, fields
+
+
+class AccountSchema(Schema):
+    address = fields.String()
+
+
+class NotificationSchema(Schema):
+    id = fields.String()
+    notification_type = fields.String()
+    title = fields.String(allow_none=True)
+    message = fields.String()
+    account = fields.Nested(AccountSchema)
+    created_at = fields.DateTime()
+    read_by = fields.List(fields.String())

--- a/backend/spherre/app/views/notifications.py
+++ b/backend/spherre/app/views/notifications.py
@@ -1,0 +1,42 @@
+import traceback
+
+from flask import Blueprint, jsonify, request
+
+from spherre.app.serializers.notifications import NotificationSchema
+from spherre.app.service.account import AccountService
+from spherre.app.service.notification import NotificationService
+
+notifications_blueprint = Blueprint("notifications", __name__, url_prefix="/api/v1")
+
+
+@notifications_blueprint.route(
+    "/accounts/<string:account_address>/notifications", methods=["GET"]
+)
+def get_notifications(account_address):
+    try:
+        page = request.args.get("page", default=1, type=int)
+        per_page = request.args.get("per_page", default=20, type=int)
+        unread_only = request.args.get("unread_only", default="False").lower() == "true"
+        member_id = request.args.get("member_id", default=None, type=str)
+
+        if page <= 0 or per_page <= 0:
+            return jsonify({"error": "Invalid pagination parameters"}), 400
+
+        account = AccountService.get_account_by_address(account_address)
+        if not account:
+            return jsonify({"error": "Account not found"}), 404
+        notifications, pagination = NotificationService.list_notifications_by_account(
+            account_id=account.id,
+            page=page,
+            per_page=per_page,
+            unread_only=unread_only,
+            member_id=member_id,
+        )
+        schema = NotificationSchema(many=True)
+        serialized = schema.dump(notifications)
+
+        return jsonify({"notifications": serialized, "pagination": pagination}), 200
+
+    except Exception as e:
+        traceback.print_exc()
+        return jsonify({"error": str(e)}), 500

--- a/backend/spherre/tests/test_service/test_notification_service.py
+++ b/backend/spherre/tests/test_service/test_notification_service.py
@@ -82,7 +82,9 @@ class TestNotificationService(TestCase):
             "Received",
         )
 
-        notifications = self.service.list_notifications_by_account(self.account_id)
+        notifications, _pagination = self.service.list_notifications_by_account(
+            self.account_id
+        )
         self.assertEqual(len(notifications), 2)
 
     def test_list_notifications_unread_only(self):
@@ -102,7 +104,7 @@ class TestNotificationService(TestCase):
         # Mark n1 as read
         self.service.mark_notification_as_read(n1.id, self.member.id)
 
-        unread = self.service.list_notifications_by_account(
+        unread, _pagination = self.service.list_notifications_by_account(
             self.account_id, unread_only=True, member_id=self.member.id
         )
         self.assertEqual(len(unread), 1)

--- a/backend/spherre/tests/test_views/test_notifications_view.py
+++ b/backend/spherre/tests/test_views/test_notifications_view.py
@@ -1,0 +1,111 @@
+import unittest
+from unittest.mock import patch
+from uuid import uuid4
+
+from spherre.app import create_app, db
+from spherre.app.models import Account, Member, Notification, NotificationType
+from spherre.app.service.notification import NotificationService
+
+
+class TestNotificationViews(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app()
+        self.client = self.app.test_client()
+        self.ctx = self.app.app_context()
+        self.ctx.push()
+        db.create_all()
+
+        # Create a member and account
+        self.member = Member(
+            id=str(uuid4()), email="test@example.com", address="0x" + "1" * 64
+        )
+        self.account = Account(
+            id=str(uuid4()), address="0x" + "2" * 64, name="Test Account"
+        )
+        db.session.add(self.member)
+        db.session.add(self.account)
+        db.session.commit()
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+        self.ctx.pop()
+
+    def create_notification(
+        self, title="Test Title", message="Test Message", read_by=None
+    ):
+        notif = Notification(
+            id=str(uuid4()),
+            account_id=self.account.id,
+            notification_type=NotificationType.TRANSACTION,
+            title=title,
+            message=message,
+        )
+        if read_by:
+            notif.read_by.extend(read_by)
+        db.session.add(notif)
+        db.session.commit()
+        return notif
+
+    def test_get_notifications_success(self):
+        # Create notifications
+        self.create_notification(title="Notif 1")
+        self.create_notification(title="Notif 2")
+
+        res = self.client.get(f"/api/v1/accounts/{self.account.address}/notifications")
+        self.assertEqual(res.status_code, 200)
+
+        data = res.get_json()
+        self.assertIn("notifications", data)
+        self.assertEqual(len(data["notifications"]), 2)
+        self.assertEqual(data["pagination"]["total"], 2)
+
+    def test_get_notifications_with_pagination(self):
+        for i in range(5):
+            self.create_notification(title=f"Notif {i}")
+
+        res = self.client.get(
+            f"/api/v1/accounts/{self.account.address}/notifications?page=1&per_page=2"
+        )
+        self.assertEqual(res.status_code, 200)
+
+        data = res.get_json()
+        self.assertEqual(len(data["notifications"]), 2)
+        self.assertEqual(data["pagination"]["pages"], 3)
+
+    def test_get_notifications_unread_only(self):
+        # Create one read and one unread notification
+        _read_notif = self.create_notification(
+            title="Read Notif", read_by=[self.member]
+        )
+        _unread_notif = self.create_notification(title="Unread Notif")
+
+        res = self.client.get(
+            f"/api/v1/accounts/{self.account.address}/notifications?unread_only=true&member_id={self.member.id}"
+        )
+        self.assertEqual(res.status_code, 200)
+
+        data = res.get_json()
+        self.assertEqual(len(data["notifications"]), 1)
+        self.assertEqual(data["notifications"][0]["title"], "Unread Notif")
+
+    def test_get_notifications_invalid_pagination(self):
+        res = self.client.get(
+            f"/api/v1/accounts/{self.account.address}/notifications?page=0&per_page=-5"
+        )
+        self.assertEqual(res.status_code, 400)
+
+    def test_get_notifications_account_not_found(self):
+        res = self.client.get(f"/api/v1/accounts/{uuid4()}/notifications")
+        self.assertEqual(res.status_code, 404)
+
+    def test_get_notifications_server_error(self):
+        with patch.object(
+            NotificationService,
+            "list_notifications_by_account",
+            side_effect=Exception("DB Error"),
+        ):
+            res = self.client.get(
+                f"/api/v1/accounts/{self.account.address}/notifications"
+            )
+            self.assertEqual(res.status_code, 500)


### PR DESCRIPTION
…tion

## Description

This pull request implements the GET /api/v1/accounts/{account_address}/notifications endpoint, enabling retrieval of notifications for a specific Spherre account with full pagination, filtering, and serialization support.

## Related Issue

<!-- Link to the issue this pull request addresses (if applicable). -->
Fixes #160 

## Type of Change

- [ X] Bug fix
- [ X] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe)

## How Has This Been Tested?

<!-- Describe the testing that has been done to verify this change works. -->
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Other (please describe)

## Checklist:

- [ X] I have read the contributing guidelines.
- [ ] I have updated the documentation (if applicable).
- [ X] My changes do not break existing functionality.
- [ X] I have added tests that cover my changes (if applicable).
- [X ] All new and existing tests pass.
- [ ] I have included screenshots or GIFs to demonstrate the changes (if applicable).

## Screenshots (if applicable)

<!-- Include screenshots or GIFs of the visual changes or outputs. -->

## Additional Notes

<!-- Provide any additional context or notes about the pull request. -->